### PR TITLE
hudson.tasks.BuildStep#getProjectActions can't return null

### DIFF
--- a/src/main/java/com/hello2morrow/sonargraph/jenkinsplugin/controller/AbstractSonargraphRecorder.java
+++ b/src/main/java/com/hello2morrow/sonargraph/jenkinsplugin/controller/AbstractSonargraphRecorder.java
@@ -57,10 +57,9 @@ public abstract class AbstractSonargraphRecorder extends Recorder
     @Override
     public Collection<Action> getProjectActions(AbstractProject<?, ?> project)
     {
-        Collection<Action> actions = null;
+        Collection<Action> actions = new ArrayList<Action>();
         if (project instanceof Project)
         {
-            actions = new ArrayList<Action>();
             actions.add(new SonargraphChartAction((Project<?, ?>) project, this));
             actions.add(new SonargraphHTMLReportAction((Project<?, ?>) project, this));
         }


### PR DESCRIPTION
see http://javadoc.jenkins-ci.org/hudson/tasks/BuildStep.html#getProjectActions(hudson.model.AbstractProject)
returning null cause NullPointerException configuring sonargraph post build in a maven project
