### PR TITLE
Don't Discard the Build Env Variables when Launching Maven

### DIFF
--- a/src/main/java/com/hello2morrow/sonargraph/jenkinsplugin/controller/SonargraphReportBuilder.java
+++ b/src/main/java/com/hello2morrow/sonargraph/jenkinsplugin/controller/SonargraphReportBuilder.java
@@ -120,9 +120,9 @@ public class SonargraphReportBuilder extends AbstractSonargraphRecorder
         HashMap<String, String> envVars = new HashMap<String, String>();
         procStarter.cmdAsSingleString(mvnCommand);
         procStarter.stdout(listener.getLogger());
-        procStarter = procStarter.pwd(build.getWorkspace()).envs(build.getEnvironment(listener));
+        envVars.putAll(build.getEnvironment(listener));
         envVars.put(M2_HOME, mavenInstallation);
-        procStarter.envs(envVars);
+        procStarter = procStarter.pwd(build.getWorkspace()).envs(envVars);
         Proc proc = launcher.launch(procStarter);
         int processExitCode = proc.join();
 


### PR DESCRIPTION
Other build variables (like JAVA_HOME from Project SDK selection) are no longer discarded when setting M2_HOME on the Maven process launcher.

This is caused by ProcStarter.envs not being additive. It replaces the previous envs with an environment that just has M2_HOME.